### PR TITLE
Play audio through loudspeaker on iOS

### DIFF
--- a/ios/OGWaverformView.m
+++ b/ios/OGWaverformView.m
@@ -78,6 +78,8 @@
     NSError *error = nil;
     _player =[[AVPlayer alloc]initWithURL:soundURL];
 
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error: nil];
+
     // Subscribe to the AVPlayerItem's DidPlayToEndTime notification.
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemDidFinishPlaying:) name:AVPlayerItemDidPlayToEndTimeNotification object:_player.currentItem];
 


### PR DESCRIPTION
It defaults to using the earpiece which is muted by the mute switch, so this change makes audio play through the speaker without being muted.