### PR TITLE
Fix conflicting RN gradle dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    compileOnly 'com.facebook.react:react-native:0.20.+'
 }
   


### PR DESCRIPTION
Switch RN dependency to compileOnly to avoid conflict when used in projects with newer RN version