### PR TITLE
Fixed Type issue.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+export declare module 'react-native-audiowaveform' {
+  import { ComponentType } from 'react';
+  import { NativeWaveType, WaveObjectPropsType } from 'react-native-audiowaveform';
+
+  const WaveForm: ComponentType<WaveObjectPropsType>;
+  export default WaveForm;
+}
+
+export declare type NativeWaveType = {
+  componentID: number;
+} & WaveObjectPropsType;
+  
+export declare type WaveObjectPropsType = {
+  autoPlay: boolean;
+  play: boolean;
+  source: number;
+  stop: boolean;
+  style?: number | null;
+  waveFormStyle?: WaveformStyleType | null;
+  onPress?: (() => void) | null;
+  onFinishPlay?: (() => void) | null;
+  earpiece: boolean;
+};
+  
+export  declare type WaveformStyleType = {
+  scrubColor: string;
+  waveColor: string;
+};


### PR DESCRIPTION
Removes the following type error in react native

could not find a declaration file for module 'react-native-audiowaveform'. '/Users/belgin/Downloads/iCare/node_modules/react-native-audiowaveform/index.js' implicitly has an 'any' type.